### PR TITLE
Add default update resource

### DIFF
--- a/src/resource.js
+++ b/src/resource.js
@@ -104,6 +104,7 @@ module.exports = function (Vue) {
         get: {method: 'get'},
         save: {method: 'post'},
         query: {method: 'get'},
+        update: {method: 'put'},
         remove: {method: 'delete'},
         delete: {method: 'delete'}
 


### PR DESCRIPTION
One might argue that `PATCH` is more accurate, but `PUT` is what's widely used.

You can always override it when creating the resource.