### PR TITLE
Fix json content type

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -9,7 +9,7 @@ var Promise = require('./lib/promise');
 module.exports = function (_) {
 
     var originUrl = _.url.parse(location.href);
-    var jsonType = {'Content-Type': 'application/json;charset=utf-8'};
+    var jsonType = {'Content-Type': 'application/json'};
 
     function Http(url, options) {
 


### PR DESCRIPTION
There is no `charset` for `application/json`. via http://tools.ietf.org/html/rfc4627

http://www.iana.org/assignments/media-types/application/json

> Note:  No "charset" parameter is defined for this registration.
> Adding one really has no effect on compliant recipients.

There are servers that will compare `headers['Content-Type'] == 'application/json'`.