### PR TITLE
Remove default headers for DELETE fixes #170

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -137,7 +137,7 @@ module.exports = function (_) {
         put: jsonType,
         post: jsonType,
         patch: jsonType,
-        delete: jsonType,
+        delete: {},
         common: {'Accept': 'application/json, text/plain, */*'},
         custom: {'X-Requested-With': 'XMLHttpRequest'}
     };


### PR DESCRIPTION
many servers answer with a 4xx status when they get a body with a DELETE request.
So, I think the default should be no headers.