### PR TITLE
Extend xhr object with deep copy.

### DIFF
--- a/src/http/client/xhr.js
+++ b/src/http/client/xhr.js
@@ -17,7 +17,7 @@ module.exports = function (request) {
         xhr.open(request.method, _.url(request), true);
 
         if (_.isPlainObject(request.xhr)) {
-            _.extend(xhr, request.xhr);
+            _.extend(true, xhr, request.xhr);
         }
 
         _.each(request.headers || {}, function (value, header) {


### PR DESCRIPTION
This allows to tap into upload.* events too.

```js
$http.get('/blah', null, null, {xhr: {upload: {onprogress: function(event) { return true}}}});
```