### PR TITLE
refactor _.warn and _.error wrappers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,7 @@
  */
 
 function install(Vue) {
-
-    var _ = require('./util');
-
-    _.config = Vue.config;
-    _.warning = Vue.util.warn;
-    _.nextTick = Vue.util.nextTick;
+    var _ = require('./util')(Vue);
 
     Vue.url = require('./url');
     Vue.http = require('./http');

--- a/src/util.js
+++ b/src/util.js
@@ -2,121 +2,134 @@
  * Utility functions.
  */
 
-var _ = exports, array = [], console = window.console;
+(function() {
+    var _ = {};
 
-_.warn = function (msg) {
-    if (console && _.warning && (!_.config.silent || _.config.debug)) {
-        console.warn('[VueResource warn]: ' + msg);
-    }
-};
-
-_.error = function (msg) {
-    if (console) {
-        console.error(msg);
-    }
-};
-
-_.trim = function (str) {
-    return str.replace(/^\s*|\s*$/g, '');
-};
-
-_.toLower = function (str) {
-    return str ? str.toLowerCase() : '';
-};
-
-_.isArray = Array.isArray;
-
-_.isString = function (val) {
-    return typeof val === 'string';
-};
-
-_.isFunction = function (val) {
-    return typeof val === 'function';
-};
-
-_.isObject = function (obj) {
-    return obj !== null && typeof obj === 'object';
-};
-
-_.isPlainObject = function (obj) {
-    return _.isObject(obj) && Object.getPrototypeOf(obj) == Object.prototype;
-};
-
-_.options = function (fn, obj, options) {
-
-    options = options || {};
-
-    if (_.isFunction(options)) {
-        options = options.call(obj);
+    if (_ && _.config) {
+        return module.exports = _;
     }
 
-    return _.merge(fn.bind({$vm: obj, $options: options}), fn, {$options: options});
-};
+    module.exports = function(Vue) {
+        var array = [], console = window.console;
 
-_.each = function (obj, iterator) {
+        _.config = Vue.config;
+        _.warning = Vue.util.warn;
+        _.nextTick = Vue.util.nextTick;
 
-    var i, key;
+        _.warn = (console && _.warning && (!_.config.silent || _.config.debug))
+            ? Function.bind.call(console.warn, console, '[VueResource warn]: ')
+            : _.warn = function () {}
 
-    if (typeof obj.length == 'number') {
-        for (i = 0; i < obj.length; i++) {
-            iterator.call(obj[i], obj[i], i);
-        }
-    } else if (_.isObject(obj)) {
-        for (key in obj) {
-            if (obj.hasOwnProperty(key)) {
-                iterator.call(obj[key], obj[key], key);
+        _.error = (console)
+            ? Function.bind.call(console.error, console)
+            : _.error = function() {}
+
+        _.trim = function (str) {
+            return str.replace(/^\s*|\s*$/g, '');
+        };
+
+        _.toLower = function (str) {
+            return str ? str.toLowerCase() : '';
+        };
+
+        _.isArray = Array.isArray;
+
+        _.isString = function (val) {
+            return typeof val === 'string';
+        };
+
+        _.isFunction = function (val) {
+            return typeof val === 'function';
+        };
+
+        _.isObject = function (obj) {
+            return obj !== null && typeof obj === 'object';
+        };
+
+        _.isPlainObject = function (obj) {
+            return _.isObject(obj) && Object.getPrototypeOf(obj) == Object.prototype;
+        };
+
+        _.options = function (fn, obj, options) {
+
+            options = options || {};
+
+            if (_.isFunction(options)) {
+                options = options.call(obj);
+            }
+
+            return _.merge(fn.bind({$vm: obj, $options: options}), fn, {$options: options});
+        };
+
+        _.each = function (obj, iterator) {
+
+            var i, key;
+
+            if (typeof obj.length == 'number') {
+                for (i = 0; i < obj.length; i++) {
+                    iterator.call(obj[i], obj[i], i);
+                }
+            } else if (_.isObject(obj)) {
+                for (key in obj) {
+                    if (obj.hasOwnProperty(key)) {
+                        iterator.call(obj[key], obj[key], key);
+                    }
+                }
+            }
+
+            return obj;
+        };
+
+        _.defaults = function (target, source) {
+
+            for (var key in source) {
+                if (target[key] === undefined) {
+                    target[key] = source[key];
+                }
+            }
+
+            return target;
+        };
+
+        _.extend = function (target) {
+
+            var args = array.slice.call(arguments, 1);
+
+            args.forEach(function (arg) {
+                merge(target, arg);
+            });
+
+            return target;
+        };
+
+        _.merge = function (target) {
+
+            var args = array.slice.call(arguments, 1);
+
+            args.forEach(function (arg) {
+                merge(target, arg, true);
+            });
+
+            return target;
+        };
+
+        function merge(target, source, deep) {
+            for (var key in source) {
+                if (deep && (_.isPlainObject(source[key]) || _.isArray(source[key]))) {
+                    if (_.isPlainObject(source[key]) && !_.isPlainObject(target[key])) {
+                        target[key] = {};
+                    }
+                    if (_.isArray(source[key]) && !_.isArray(target[key])) {
+                        target[key] = [];
+                    }
+                    merge(target[key], source[key], deep);
+                } else if (source[key] !== undefined) {
+                    target[key] = source[key];
+                }
             }
         }
+
+        module.exports = _;
+        return _;
     }
-
-    return obj;
-};
-
-_.defaults = function (target, source) {
-
-    for (var key in source) {
-        if (target[key] === undefined) {
-            target[key] = source[key];
-        }
-    }
-
-    return target;
-};
-
-_.extend = function (target) {
-
-    var args = array.slice.call(arguments, 1);
-
-    args.forEach(function (arg) {
-        merge(target, arg);
-    });
-
-    return target;
-};
-
-_.merge = function (target) {
-
-    var args = array.slice.call(arguments, 1);
-
-    args.forEach(function (arg) {
-        merge(target, arg, true);
-    });
-
-    return target;
-};
-
-function merge(target, source, deep) {
-    for (var key in source) {
-        if (deep && (_.isPlainObject(source[key]) || _.isArray(source[key]))) {
-            if (_.isPlainObject(source[key]) && !_.isPlainObject(target[key])) {
-                target[key] = {};
-            }
-            if (_.isArray(source[key]) && !_.isArray(target[key])) {
-                target[key] = [];
-            }
-            merge(target[key], source[key], deep);
-        } else if (source[key] !== undefined) {
-            target[key] = source[key];
-        }
-    }
-}
+})()


### PR DESCRIPTION
**Problem**
When calling `_.warn()` or  `_.error()`, we get the line where `console.warn()` and  `console.error()` are called (in `utils.js`) which can make it harder to debug.

<img width="502" alt="screen shot 2016-03-14 at 17 13 45" src="https://cloud.githubusercontent.com/assets/911307/13750962/247692e4-ea08-11e5-8da5-57aa3036473c.png">
*This will always be line 130*

**Solution**
This is simply binding those methods to get the actual lines where  `_.warn()` or  `_.error()` are called.

<img width="497" alt="screen shot 2016-03-14 at 21 43 27" src="https://cloud.githubusercontent.com/assets/911307/13759291/e2fbf946-ea2d-11e5-955e-b73afee40536.png">
*It now logs with the line where `_.warn()` was called.*

To do this, I had to pass the `Vue` instance on first call to `utils.js`, so `_.config` and `_.warning` are defined when `_.error()` and `_.warn()` are defined. So I changed all the thing into a function. It might not be the *cleverest* way but I didn't want to change the architecture too much.
Maybe a `config` module/file should be created to hold `Vue.config, Vue.util.warn &Vue.util.nextTick`.