### PR TITLE
Looks like a typo in docs (or change in api)

### DIFF
--- a/docs/resource.md
+++ b/docs/resource.md
@@ -24,7 +24,7 @@ new Vue({
 
     ready: function() {
 
-      var resource = this.$resource('someItem{/id}');
+      var resource = this.$resource('someItem/:id');
 
       // get item
       resource.get({id: 1}).then(function (response) {


### PR DESCRIPTION
It looks like this is a typo 'someItem{/id}' should be 'someItem/:id'.