### PR TITLE
fix resource params merge bug

### DIFF
--- a/src/resource.js
+++ b/src/resource.js
@@ -16,7 +16,7 @@ export default function Resource(url, params, actions, options) {
 
     each(actions, (action, name) => {
 
-        action = merge({url, params: params || {}}, options, action);
+        action = merge({url, params: assign({}, params)}, options, action);
 
         resource[name] = function () {
             return (self.$http || Http)(opts(action, arguments));


### PR DESCRIPTION
fix the bug:
var actions = {
      action1:  {params: {a:1}},
      action2: {params: {b:2}}
}
var resource = Vue.resource('url', {c:3}, actions);
then the params of resource.action1 and resource.action1 , will be same {a:1,b:2,c:3};