### PR TITLE
Fixed bug where resending a request didn't work

### DIFF
--- a/src/http/request.js
+++ b/src/http/request.js
@@ -14,9 +14,11 @@ export default class Request {
         this.body = null;
         this.params = {};
 
+        const headers = options.headers instanceof Headers ? options.headers : new Headers(options.headers);
+
         assign(this, options, {
             method: toUpper(options.method || 'GET'),
-            headers: new Headers(options.headers)
+            headers
         });
     }
 


### PR DESCRIPTION
You don't have tests for the interceptor functionality, and you don't have tests for failing requests, so I was unable to write a regression test for this.

Tested on our (previously broken) app, and it fixed it there.

Closes https://github.com/vuejs/vue-resource/issues/391.