### PR TITLE
Add abort to the API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -24,6 +24,7 @@
   getUrl() (string)
   getBody() (any)
   respondWith(any: body, object: options) (Response)
+  abort()
 }
 ```
 


### PR DESCRIPTION
In [this example](https://github.com/vuejs/vue-resource/blob/master/docs/recipes.md) Request seems to have an abort method. But this is not documented in the API