### PR TITLE
Fixed Typos

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -132,7 +132,7 @@ Vue.http.interceptors.push((request, next) => {
 
 ### Request and Response processing
 ```js
-Vue.http.interceptors.push((request, next)  => {
+Vue.http.interceptors.push((request, next) => {
 
   // modify request
   request.method = 'POST';


### PR DESCRIPTION
There was 2 spaces before the => (eslint is quite strict about it :D)